### PR TITLE
Auth header is hex encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are the required headers for each request:
     
 *   "**X-Auth-Key**" - Your API key string.
     
-*   "**Authorization**" - A SHA-1 hash of the X-Auth-Key, the corresponding key secret and the X-Auth-Date value concatenated as a string.
+*   "**Authorization**" - A SHA-1 hash of the X-Auth-Key, the corresponding key secret and the X-Auth-Date value concatenated as a string. The resulting hash should be encoded as hexadecimal value.
     
     The Authorizaton header is computed with something like this (pseudo-code):
     


### PR DESCRIPTION
Not sure if this is standard, but base64 sure would've been an option, so it seems useful to report here. It would have helped me a bit, using nodejs' crypto library.