### PR TITLE
Postman Docs Update

### DIFF
--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "005794c7-d322-4c4d-aa2a-2e21af901358",
+		"name": "PodcastIndex",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "getPodcasts",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "29b27df2-6a03-4c74-9bb8-38e5787207da",
+						"exec": [
+							"const authKey = pm.variables.get(\"AuthKey\");",
+							"const secretKey = pm.variables.get(\"SecretKey\");",
+							"const apiHeaderTime = new Date().getTime() / 1000;",
+							"const hash = CryptoJS.SHA1(authKey + secretKey + apiHeaderTime).toString(CryptoJS.enc.Hex);",
+							"",
+							"pm.variables.set('AuthDate', apiHeaderTime);",
+							"pm.variables.set('HashedAuth', hash);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"user-agent": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "User-Agent",
+						"value": "SuperPodcastPlayer/1.3",
+						"type": "text"
+					},
+					{
+						"key": "X-Auth-Key",
+						"value": "{{AuthKey}}",
+						"type": "text"
+					},
+					{
+						"key": "X-Auth-Date",
+						"value": "{{AuthDate}}",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "{{HashedAuth}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "https://api.podcastindex.org/api/1.0/search/byterm?q=bastiat",
+					"protocol": "https",
+					"host": [
+						"api",
+						"podcastindex",
+						"org"
+					],
+					"path": [
+						"api",
+						"1.0",
+						"search",
+						"byterm"
+					],
+					"query": [
+						{
+							"key": "q",
+							"value": "bastiat"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/Postman Docs/PodcastIndexOrgEnvironment.postman_environment.json
+++ b/Postman Docs/PodcastIndexOrgEnvironment.postman_environment.json
@@ -1,0 +1,29 @@
+{
+	"id": "8e4f3e43-8ce9-4ca6-91c8-d07701a3f93c",
+	"name": "PodcastIndexOrgEnvironment",
+	"values": [
+		{
+			"key": "AuthKey",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "AuthDate",
+			"value": "1599663190",
+			"enabled": true
+		},
+		{
+			"key": "HashedAuth",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "SecretKey",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-09-10T03:30:00.207Z",
+	"_postman_exported_using": "Postman/7.31.1"
+}

--- a/README.md
+++ b/README.md
@@ -318,3 +318,14 @@ Here are some examples to get you started.
 
     task.resume()
     semaphore.wait()
+
+**Postman**
+
+* * *
+
+1) Download the contents of the `Postman Docs` folder.
+2) Import the `PodcastIndex.postman_collection.json` collection to Postman
+3) Import the `PodcastIndexOrgEnvironment.postman_environment.json` to Postman
+4) Set the `AuthKey` environment variable 
+5) Set the `SecretKey` environment variable
+6) Hit the `Send` button (⌘ + return)


### PR DESCRIPTION
I've included a new folder with a postman collection and environment file so that developers can easily import these and run in postman after updating with their personal development keys.

One special addition here is the pre-request script that will dynamically generate the authentication hash. 
I've only included the single `search/byterm?q=` example query here, but I think this creates a nice starting point for to build out the documentation for the rest of the endpoints from.

I'm working on updating my app to use this API and I use Postman for testing a lot. As I work on my own integration I'll contribute back the rest of the endpoints as I document them (if someone doesn't beat me to it that is)

I'm not sure if this is the kind of thing you want in this repo or if this could maybe be reformatted better. Let me know and I'm happy to make updates.