### PR TITLE
Add additional endpoints to Postman Collection

### DIFF
--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -1,25 +1,19 @@
 {
 	"info": {
-		"_postman_id": "005794c7-d322-4c4d-aa2a-2e21af901358",
+		"_postman_id": "7318d71d-ba57-41ab-8543-7e02efbefe4c",
 		"name": "PodcastIndex",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "getPodcasts",
+			"name": "Podcasts - Search By Term",
 			"event": [
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "29b27df2-6a03-4c74-9bb8-38e5787207da",
+						"id": "8b686595-92f4-4056-ad78-b327af4f571c",
 						"exec": [
-							"const authKey = pm.variables.get(\"AuthKey\");",
-							"const secretKey = pm.variables.get(\"SecretKey\");",
-							"const apiHeaderTime = new Date().getTime() / 1000;",
-							"const hash = CryptoJS.SHA1(authKey + secretKey + apiHeaderTime).toString(CryptoJS.enc.Hex);",
-							"",
-							"pm.variables.set('AuthDate', apiHeaderTime);",
-							"pm.variables.set('HashedAuth', hash);"
+							""
 						],
 						"type": "text/javascript"
 					}
@@ -32,39 +26,13 @@
 			},
 			"request": {
 				"method": "GET",
-				"header": [
-					{
-						"key": "User-Agent",
-						"value": "SuperPodcastPlayer/1.3",
-						"type": "text"
-					},
-					{
-						"key": "X-Auth-Key",
-						"value": "{{AuthKey}}",
-						"type": "text"
-					},
-					{
-						"key": "X-Auth-Date",
-						"value": "{{AuthDate}}",
-						"type": "text"
-					},
-					{
-						"key": "Authorization",
-						"value": "{{HashedAuth}}",
-						"type": "text"
-					}
-				],
+				"header": [],
 				"url": {
-					"raw": "https://api.podcastindex.org/api/1.0/search/byterm?q=bastiat",
-					"protocol": "https",
+					"raw": "{{base_url}}/search/byterm?q=bastiat",
 					"host": [
-						"api",
-						"podcastindex",
-						"org"
+						"{{base_url}}"
 					],
 					"path": [
-						"api",
-						"1.0",
 						"search",
 						"byterm"
 					],
@@ -72,11 +40,306 @@
 						{
 							"key": "q",
 							"value": "bastiat"
+						},
+						{
+							"key": "pretty",
+							"value": "true",
+							"description": "If present, makes the output \"pretty\" to help with debugging.",
+							"disabled": true
+						},
+						{
+							"key": "apple",
+							"value": "true",
+							"description": "If present, only returns podcasts that also exist in Apple's directory, if we can determine that. Coming soon",
+							"disabled": true
+						},
+						{
+							"key": "itunes",
+							"value": "true",
+							"description": "If present, gives you back exactly what an itunes lookup API call would. Coming soon",
+							"disabled": true
+						},
+						{
+							"key": "max",
+							"value": "99",
+							"description": "Limits the number of results returned to the maximum number specified, where contextually appropriate.",
+							"disabled": true
+						},
+						{
+							"key": "fulltext",
+							"value": "true",
+							"description": "If present, returns the full text of long text properties, like 'description'. Otherwise, all text fields are truncated to 100 words.",
+							"disabled": true
+						}
+					]
+				},
+				"description": "This call returns all of the feeds that match the search terms in the title of the feed."
+			},
+			"response": []
+		},
+		{
+			"name": "Podcasts - By Feed URL",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/podcasts/byfeedurl?url=https://feeds.theincomparable.com/batmanuniversity",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"podcasts",
+						"byfeedurl"
+					],
+					"query": [
+						{
+							"key": "url",
+							"value": "https://feeds.theincomparable.com/batmanuniversity"
+						}
+					]
+				},
+				"description": "This call returns everything we know about the feed."
+			},
+			"response": []
+		},
+		{
+			"name": "Podcasts - By Feed ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/podcasts/byfeedid?id=75075",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"podcasts",
+						"byfeedid"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "75075"
+						}
+					]
+				},
+				"description": "This call returns everything we know about the feed."
+			},
+			"response": []
+		},
+		{
+			"name": "Podcasts - By iTunes ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/podcasts/byitunesid?id=1441923632",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"podcasts",
+						"byitunesid"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "1441923632"
+						}
+					]
+				},
+				"description": "If we have an itunes id on file for a feed, then this call returns everything we know about that feed.\n\nNote: The itunes id parameter can either be the number alone, or be prepended with \"id\"."
+			},
+			"response": []
+		},
+		{
+			"name": "Episodes - By Feed URL",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/episodes/byfeedurl?url=https://feeds.theincomparable.com/batmanuniversity",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"episodes",
+						"byfeedurl"
+					],
+					"query": [
+						{
+							"key": "url",
+							"value": "https://feeds.theincomparable.com/batmanuniversity"
+						}
+					]
+				},
+				"description": "This call returns all the episodes we know about for this feed, in reverse chronological order."
+			},
+			"response": []
+		},
+		{
+			"name": "Episodes - By Feed ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/episodes/byfeedid?id=75075",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"episodes",
+						"byfeedid"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "75075"
+						}
+					]
+				},
+				"description": "This call returns all the episodes we know about for this feed, in reverse chronological order.\n\nNote: The id parameter is the internal Podcastindex id for this feed."
+			},
+			"response": []
+		},
+		{
+			"name": "Episodes - By iTunes ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/episodes/byitunesid?id=1441923632",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"episodes",
+						"byitunesid"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "1441923632"
+						}
+					]
+				},
+				"description": "If we have an itunes id on file for a feed, then this call returns all the episodes we know about for the feed, in reverse chronological order.\n\nNote: The itunes id parameter can either be the number alone, or be prepended with \"id\"."
+			},
+			"response": []
+		},
+		{
+			"name": "Episodes - Recent",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/recent/episodes?max=7",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"recent",
+						"episodes"
+					],
+					"query": [
+						{
+							"key": "max",
+							"value": "7",
+							"description": "If no [max] is specified, the default is 10."
+						},
+						{
+							"key": "excludeString",
+							"value": null,
+							"description": "Optional: excludeString=[url encoded string] - If you pass this argument, any item containing this string will be discarded from the result set. This may, in certain cases, reduce your set size below your \"max\" value. The [excludeString] value matches against title and urls.",
+							"disabled": true
+						}
+					]
+				},
+				"description": "This call returns the most recent [max] number of episodes globally across the whole index, in reverse chronological order."
+			},
+			"response": []
+		},
+		{
+			"name": "Podcasts - Add - By Feed URL",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/add/byfeedurl?url=https://feeds.theincomparable.com/batmanuniversity",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"add",
+						"byfeedurl"
+					],
+					"query": [
+						{
+							"key": "url",
+							"value": "https://feeds.theincomparable.com/batmanuniversity"
 						}
 					]
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Podcasts - Add - By iTunes ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/add/byitunesid?id=1441923632",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"add",
+						"byitunesid"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "1441923632"
+						}
+					]
+				},
+				"description": "**This call requires a read-write api key.\n\nThis call adds a podcast to the index using it's itunes id. If a feed already exists, it will be noted in the response."
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "149f109d-ef27-470b-a812-69cc818a78e6",
+				"type": "text/javascript",
+				"exec": [
+					"const authKey = pm.variables.get(\"AuthKey\");",
+					"const secretKey = pm.variables.get(\"SecretKey\");",
+					"const userAgent = pm.variables.get(\"UserAgent\");",
+					"",
+					"const apiHeaderTime = new Date().getTime() / 1000;",
+					"const hash = CryptoJS.SHA1(authKey + secretKey + apiHeaderTime).toString(CryptoJS.enc.Hex);",
+					"",
+					"pm.request.headers.add({ key: 'User-Agent', value: 'SuperPodcastPlayer/1.3' });",
+					"pm.request.headers.add({ key: 'X-Auth-Key', value: authKey });",
+					"pm.request.headers.add({ key: 'X-Auth-Date', value: apiHeaderTime });",
+					"pm.request.headers.add({ key: 'Authorization', value: hash });",
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "c6b7dfc5-643c-4a1f-8aed-9b6104e5871f",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
 		}
 	],
 	"protocolProfileBehavior": {}

--- a/Postman Docs/PodcastIndexOrgEnvironment.postman_environment.json
+++ b/Postman Docs/PodcastIndexOrgEnvironment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "8e4f3e43-8ce9-4ca6-91c8-d07701a3f93c",
+	"id": "afddb376-0592-4fc8-a9cf-de0eda5a767b",
 	"name": "PodcastIndexOrgEnvironment",
 	"values": [
 		{
@@ -8,22 +8,17 @@
 			"enabled": true
 		},
 		{
-			"key": "AuthDate",
-			"value": "1599663190",
-			"enabled": true
-		},
-		{
-			"key": "HashedAuth",
-			"value": "",
-			"enabled": true
-		},
-		{
 			"key": "SecretKey",
 			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "base_url",
+			"value": "https://api.podcastindex.org/api/1.0",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-09-10T03:30:00.207Z",
-	"_postman_exported_using": "Postman/7.31.1"
+	"_postman_exported_at": "2020-09-14T07:01:52.013Z",
+	"_postman_exported_using": "Postman/7.32.0"
 }


### PR DESCRIPTION
I noticed the Postman Collection only had 1 request in it, so I added the other 9 currently in the documentation. Let me know if you'd like anything changed!

Note: I added the responseType, and other optional query parameters only to the podcasts search request, because I wasn't sure if you'd want me to add param fields to each request or if that was too much.