### PR TITLE
Change "url" to "name" in categories/list response

### DIFF
--- a/api_src/components/schemas/feed_categories.yaml
+++ b/api_src/components/schemas/feed_categories.yaml
@@ -2,5 +2,5 @@ type: object
 properties:
   id:
     $ref: '../properties/id_category.yaml'
-  url:
+  name:
     $ref: '../properties/name_category.yaml'

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -2043,7 +2043,7 @@
           "id": {
             "$ref": "#/components/schemas/id_category"
           },
-          "url": {
+          "name": {
             "$ref": "#/components/schemas/name_category"
           }
         }

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1952,7 +1952,7 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/id_category'
-        url:
+        name:
           $ref: '#/components/schemas/name_category'
     feeds_categories:
       description: |


### PR DESCRIPTION
In the "/categories/list" example response, the feeds are represented like this:
```
feeds: [{
    id: integer
    url: string
}]
```
However, the API actually returns:
```
feeds: [{
    id: integer
    name: string
}]
```

This change updates the documentation to match the `name` property to the API's response.