### PR TITLE
Various Updates

### DIFF
--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -36,6 +36,12 @@
 									"disabled": true
 								},
 								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n",
+									"disabled": true
+								},
+								{
 									"key": "aponly",
 									"value": "true",
 									"description": "Only returns feeds with an `itunesId`.\n",
@@ -92,6 +98,12 @@
 									"disabled": true
 								},
 								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n",
+									"disabled": true
+								},
+								{
 									"key": "clean",
 									"value": "",
 									"description": "If present, only non-explicit feeds will be returned. Meaning, feeds where the `itunes:explicit` flag is set to `false`.\n\nParameter shall not have a value\n",
@@ -142,6 +154,12 @@
 									"description": "(Required) Person search for\n"
 								},
 								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n",
+									"disabled": true
+								},
+								{
 									"key": "fulltext",
 									"value": "",
 									"description": "If present, return the full text value of any text fields (ex: `description`). If not provided, field value is truncated to 100 words.\n\nParameter shall not have a value\n",
@@ -190,6 +208,12 @@
 									"key": "aponly",
 									"value": "true",
 									"description": "Only returns feeds with an `itunesId`.\n",
+									"disabled": true
+								},
+								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n",
 									"disabled": true
 								},
 								{
@@ -411,6 +435,12 @@
 									"key": "medium",
 									"value": "video",
 									"description": "(Required) The medium value to search for.\n\nFull list of possible values documented in [medium](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#medium) tag spec."
+								},
+								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n",
+									"disabled": true
 								},
 								{
 									"key": "pretty",

--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -519,7 +519,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/episodes/byfeedid?id=75075",
+							"raw": "{{baseUrl}}/episodes/byfeedid?id=41504",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -530,7 +530,7 @@
 							"query": [
 								{
 									"key": "id",
-									"value": "75075",
+									"value": "41504",
 									"description": "(Required) The PodcastIndex Feed ID or IDs to search for.\n\nIf searching for multiple IDs, separate values with a comma. A maximum of 200 IDs can be provided.\n"
 								},
 								{
@@ -543,6 +543,12 @@
 									"key": "max",
 									"value": "10",
 									"description": "Maximum number of results to return.\n",
+									"disabled": true
+								},
+								{
+									"key": "enclosure",
+									"value": "https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3",
+									"description": "The URL for the episode enclosure to get the information for.\n",
 									"disabled": true
 								},
 								{
@@ -559,7 +565,7 @@
 								}
 							]
 						},
-						"description": "This call returns all the episodes we know about for this feed from the PodcastIndex ID. Episodes are in reverse chronological order.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty\n  - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty\n"
+						"description": "This call returns all the episodes we know about for this feed from the PodcastIndex ID.\nEpisodes are in reverse chronological order.\n\nWhen using the `enclosure` parameter, only the episode matching the URL is returned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty\n  - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty\n  - Includes `value`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=4058673&pretty\n  - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty\n"
 					},
 					"response": []
 				},
@@ -669,7 +675,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/episodes/byitunesid?id=1441923632",
+							"raw": "{{baseUrl}}/episodes/byitunesid?id=269169796",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -680,7 +686,7 @@
 							"query": [
 								{
 									"key": "id",
-									"value": "1441923632",
+									"value": "269169796",
 									"description": "(Required) The iTunes Feed ID to search for\n"
 								},
 								{
@@ -693,6 +699,12 @@
 									"key": "max",
 									"value": "10",
 									"description": "Maximum number of results to return.\n",
+									"disabled": true
+								},
+								{
+									"key": "enclosure",
+									"value": "https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3",
+									"description": "The URL for the episode enclosure to get the information for.\n",
 									"disabled": true
 								},
 								{
@@ -709,7 +721,7 @@
 								}
 							]
 						},
-						"description": "This call returns all the episodes we know about for this feed from the iTunes ID. Episodes are in reverse chronological order.\n\nExample: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty\n"
+						"description": "This call returns all the episodes we know about for this feed from the iTunes ID.\nEpisodes are in reverse chronological order.\n\nWhen using the `enclosure` parameter, only the episode matching the URL is returned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty\n  - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=269169796&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty\n"
 					},
 					"response": []
 				},

--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -1558,7 +1558,7 @@
 					"const apiHeaderTime = new Date().getTime() / 1000;",
 					"const hash = CryptoJS.SHA1(authKey + secretKey + apiHeaderTime).toString(CryptoJS.enc.Hex);",
 					"",
-					"pm.request.headers.add({ key: 'User-Agent', value: 'SuperPodcastPlayer/1.3' });",
+					"pm.request.headers.add({ key: 'User-Agent', value: 'PostmanAPITester/1.3' });",
 					"pm.request.headers.add({ key: 'X-Auth-Key', value: authKey });",
 					"pm.request.headers.add({ key: 'X-Auth-Date', value: apiHeaderTime.toString() });",
 					"pm.request.headers.add({ key: 'Authorization', value: hash });",

--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -155,7 +155,7 @@
 								}
 							]
 						},
-						"description": "This call returns all of the episodes where the specified person is mentioned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=adam%20curry&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Martin+Mouritzen&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Klaus+Schwab&pretty\n"
+						"description": "This call returns all of the episodes where the specified person is mentioned.\n\nIt searches the following fields:\n\n  - Person tags\n  - Episode title\n  - Episode description\n  - Feed owner\n  - Feed author\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=adam%20curry&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Martin+Mouritzen&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Klaus+Schwab&pretty\n"
 					},
 					"response": []
 				},

--- a/Postman Docs/PodcastIndex.postman_collection.json
+++ b/Postman Docs/PodcastIndex.postman_collection.json
@@ -355,7 +355,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/podcasts/bytag?podcast-value=",
+							"raw": "{{baseUrl}}/podcasts/bytag?podcast-value=&max=20",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -370,6 +370,17 @@
 									"description": "(Required) Get feeds supporting the `value` tag.\n\nParameter shall not have a value\n"
 								},
 								{
+									"key": "max",
+									"value": "20",
+									"description": "Maximum number of results to return.\n"
+								},
+								{
+									"key": "start_at",
+									"value": "",
+									"description": "Feed ID to start at for request\n",
+									"disabled": true
+								},
+								{
 									"key": "pretty",
 									"value": "",
 									"description": "If present, makes the output “pretty” to help with debugging.\n\nParameter shall not have a value\n",
@@ -377,7 +388,7 @@
 								}
 							]
 						},
-						"description": "This call returns all feeds that support the specified [podcast namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md) tag.\n\nExample: https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&pretty\n"
+						"description": "This call returns all feeds that support the specified\n[podcast namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md) tag.\n\n\nWhen called without a `start_at` value, the top 500 feeds sorted by popularity are returned in descending order.\n\n\nWhen called with a `start_at` value, the feeds are returned sorted by the `feedId` starting with the specified value\nup to the max number of feeds to return. The `nextStartAt` specifies the value to pass to the next `start_at`.\nRepeat this sequence until no items are returned.\n\n\nExamples:\n  - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&pretty\n  - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&start_at=1&pretty"
 					},
 					"response": []
 				},
@@ -768,7 +779,8 @@
 								{
 									"key": "feedurl",
 									"value": "http://mp3s.nashownotes.com/pc20rss.xml",
-									"description": "The Feed URL\n"
+									"description": "The Feed URL\n",
+									"disabled": true
 								},
 								{
 									"key": "fulltext",
@@ -1500,7 +1512,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseAppleUrl}}/lookup?id=1441923632",
+							"raw": "{{baseAppleUrl}}/lookup?id=1441923632&entity=podcast",
 							"host": [
 								"{{baseAppleUrl}}"
 							],

--- a/api_src/components/parameters/enclosure.yaml
+++ b/api_src/components/parameters/enclosure.yaml
@@ -1,0 +1,9 @@
+name: enclosure
+in: query
+# language=Markdown
+description: >
+  The URL for the episode enclosure to get the information for.
+required: false
+schema:
+  type: string
+example: "https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3"

--- a/api_src/components/parameters/max_5000.yaml
+++ b/api_src/components/parameters/max_5000.yaml
@@ -1,0 +1,10 @@
+name: max
+in: query
+# language=Markdown
+description: >
+  Maximum number of results to return.
+schema:
+  type: integer
+  minimum: 1
+  maximum: 5000
+example: 200

--- a/api_src/components/parameters/start_at.yaml
+++ b/api_src/components/parameters/start_at.yaml
@@ -1,0 +1,9 @@
+name: start_at
+in: query
+# language=Markdown
+description: >
+  Feed ID to start at for request
+schema:
+  type: integer
+  minimum: 1
+example: 1

--- a/api_src/components/properties/feedImageUrlHash.yaml
+++ b/api_src/components/properties/feedImageUrlHash.yaml
@@ -1,0 +1,5 @@
+  # language=Markdown
+description: >
+  A CRC32 hash of the `feedImage` URL with the protocol (`http://`, `https://`) removed.
+type: integer
+example: 1639321931

--- a/api_src/components/properties/feed_itunes.yaml
+++ b/api_src/components/properties/feed_itunes.yaml
@@ -53,6 +53,8 @@ properties:
     $ref: '../properties/crawlErrors.yaml'
   parseErrors:
     $ref: '../properties/parseErrors.yaml'
+  categories:
+    $ref: '../properties/categories.yaml'
   locked:
     $ref: '../properties/locked.yaml'
   funding:

--- a/api_src/components/properties/imageUrlHash.yaml
+++ b/api_src/components/properties/imageUrlHash.yaml
@@ -1,14 +1,5 @@
   # language=Markdown
 description: >
   A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed.
-  Can be used to retrieve a resized/converted version of the image specified by `image` from https://podcastimages.com/.
-
-
-  Using the format: `https://podcastimages.com/<hash>_<size>.jpg`
-  Replace `<hash>` with the value in this field. The `<size>` is the desired image width/height.
-  Ex: `https://podcastimages.com/1011338142_600.jpg`
-
-
-  **Work in Progress**: the `podcastimages.com` system is currently not working.
 type: integer
 example: 1639321931

--- a/api_src/components/properties/nextStartAt.yaml
+++ b/api_src/components/properties/nextStartAt.yaml
@@ -1,0 +1,8 @@
+  # language=Markdown
+description: >
+  Feed ID to pass to next `start_at` to get next batch of feeds
+
+
+  Only returned when `start_at` passed to request
+type: integer
+example: 322043

--- a/api_src/components/properties/total.yaml
+++ b/api_src/components/properties/total.yaml
@@ -1,0 +1,5 @@
+  # language=Markdown
+description: >
+  Total number of feeds returnable by endpoint
+type: integer
+example: 13143

--- a/api_src/components/properties/transcriptUrl.yaml
+++ b/api_src/components/properties/transcriptUrl.yaml
@@ -1,6 +1,9 @@
   # language=Markdown
 description: >
   Link to the file containing the episode transcript
+
+
+  Note: in most use cases, the `transcripts` value should be used instead
 type: string
 format: URL
 example: "https://mp3s.nashownotes.com/NA-1322-Captions.srt"

--- a/api_src/components/responses/podcasts_bytag.yaml
+++ b/api_src/components/responses/podcasts_bytag.yaml
@@ -10,5 +10,9 @@ content:
           $ref: '../properties/feeds_bytag.yaml'
         count:
           $ref: '../properties/count.yaml'
+        total:
+          $ref: '../properties/total.yaml'
+        nextStartAt:
+          $ref: '../properties/nextStartAt.yaml'
         description:
           $ref: '../properties/description_response.yaml'

--- a/api_src/components/schemas/feed_bytag.yaml
+++ b/api_src/components/schemas/feed_bytag.yaml
@@ -50,6 +50,8 @@ properties:
     $ref: '../properties/categories.yaml'
   locked:
     $ref: '../properties/locked.yaml'
+  popularity:
+    $ref: '../properties/trendScore.yaml'
   imageUrlHash:
     $ref: '../properties/imageUrlHash.yaml'
   value:

--- a/api_src/components/schemas/item_itunesId.yaml
+++ b/api_src/components/schemas/item_itunesId.yaml
@@ -42,11 +42,23 @@ properties:
     $ref: '../properties/id_feed.yaml'
   feedLanguage:
     $ref: '../properties/language.yaml'
+  feedDead:
+    $ref: '../properties/dead.yaml'
+  feedDuplicateOf:
+    $ref: '../properties/duplicateOf.yaml'
   chaptersUrl:
     $ref: '../properties/chaptersUrl.yaml'
   transcriptUrl:
     $ref: '../properties/transcriptUrl.yaml'
+  transcripts:
+    $ref: '../properties/transcripts.yaml'
   soundbite:
     $ref: '../properties/soundbite.yaml'
   soundbites:
     $ref: '../properties/soundbites.yaml'
+  persons:
+    $ref: '../properties/persons.yaml'
+  socialInteract:
+    $ref: '../properties/socialInteract.yaml'
+  value:
+    $ref: '../properties/value.yaml'

--- a/api_src/components/schemas/item_podcast_byid.yaml
+++ b/api_src/components/schemas/item_podcast_byid.yaml
@@ -32,10 +32,14 @@ season:
   $ref: '../properties/season.yaml'
 image:
   $ref: '../properties/image_episode.yaml'
+imageUrlHash:
+  $ref: '../properties/imageUrlHash.yaml'
 feedItunesId:
   $ref: '../properties/itunesId_feed.yaml'
 feedImage:
   $ref: '../properties/image_feed.yaml'
+feedImageUrlHash:
+  $ref: '../properties/feedImageUrlHash.yaml'
 feedId:
   $ref: '../properties/id_feed.yaml'
 feedTitle:

--- a/api_src/components/schemas/item_search_byperson.yaml
+++ b/api_src/components/schemas/item_search_byperson.yaml
@@ -48,5 +48,7 @@ properties:
     $ref: '../properties/language.yaml'
   chaptersUrl:
     $ref: '../properties/chaptersUrl.yaml'
+  transcriptUrl:
+    $ref: '../properties/transcriptUrl.yaml'
   transcripts:
     $ref: '../properties/transcripts.yaml'

--- a/api_src/paths/episodes/byfeedid.yaml
+++ b/api_src/paths/episodes/byfeedid.yaml
@@ -8,12 +8,16 @@ get:
     Episodes are in reverse chronological order.
 
 
+    When using the `enclosure` parameter, only the episode matching the URL is returned.
+
+
     Examples:
 
       - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty
       - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty
       - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty
       - Includes `value`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=4058673&pretty
+      - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty
   operationId: episodes/byfeedid
   security:
     - $ref: '../../components/security/security.yaml'
@@ -21,6 +25,7 @@ get:
     - $ref: '../../components/parameters/id_feed_episode_pi.yaml'
     - $ref: '../../components/parameters/since.yaml'
     - $ref: '../../components/parameters/max.yaml'
+    - $ref: '../../components/parameters/enclosure.yaml'
     - $ref: '../../components/parameters/fulltext.yaml'
     - $ref: '../../components/parameters/pretty.yaml'
   responses:

--- a/api_src/paths/episodes/byitunesid.yaml
+++ b/api_src/paths/episodes/byitunesid.yaml
@@ -8,7 +8,13 @@ get:
     Episodes are in reverse chronological order.
 
 
-    Example: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty
+    When using the `enclosure` parameter, only the episode matching the URL is returned.
+
+
+    Examples:
+
+      - https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty
+      - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=269169796&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty
   operationId: episodes/byitunesid
   security:
     - $ref: '../../components/security/security.yaml'
@@ -16,6 +22,7 @@ get:
     - $ref: '../../components/parameters/id_feed_podcast_itunes.yaml'
     - $ref: '../../components/parameters/since.yaml'
     - $ref: '../../components/parameters/max.yaml'
+    - $ref: '../../components/parameters/enclosure.yaml'
     - $ref: '../../components/parameters/fulltext.yaml'
     - $ref: '../../components/parameters/pretty.yaml'
   responses:

--- a/api_src/paths/podcasts/bymedium.yaml
+++ b/api_src/paths/podcasts/bymedium.yaml
@@ -14,6 +14,7 @@ get:
     - $ref: '../../components/security/security.yaml'
   parameters:
     - $ref: '../../components/parameters/medium.yaml'
+    - $ref: '../../components/parameters/max.yaml'
     - $ref: '../../components/parameters/pretty.yaml'
   responses:
     '200':

--- a/api_src/paths/podcasts/bytag.yaml
+++ b/api_src/paths/podcasts/bytag.yaml
@@ -8,12 +8,24 @@ get:
     [podcast namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md) tag.
 
 
-    Example: https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&pretty
+    When called without a `start_at` value, the top 500 feeds sorted by popularity are returned in descending order.
+
+
+    When called with a `start_at` value, the feeds are returned sorted by the `feedId` starting with the specified value
+    up to the max number of feeds to return. The `nextStartAt` specifies the value to pass to the next `start_at`.
+    Repeat this sequence until no items are returned.
+
+
+    Examples:
+      - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&pretty
+      - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&start_at=1&pretty
   operationId: podcasts/bytag
   security:
     - $ref: '../../components/security/security.yaml'
   parameters:
     - $ref: '../../components/parameters/podcast-value.yaml'
+    - $ref: '../../components/parameters/max_5000.yaml'
+    - $ref: '../../components/parameters/start_at.yaml'
     - $ref: '../../components/parameters/pretty.yaml'
   responses:
     '200':

--- a/api_src/paths/search/byperson.yaml
+++ b/api_src/paths/search/byperson.yaml
@@ -6,6 +6,15 @@ get:
   description: >
     This call returns all of the episodes where the specified person is mentioned.
 
+    
+    It searches the following fields:
+
+      - Person tags
+      - Episode title
+      - Episode description
+      - Feed owner
+      - Feed author
+
 
     Examples:
 

--- a/api_src/paths/search/byperson.yaml
+++ b/api_src/paths/search/byperson.yaml
@@ -26,6 +26,7 @@ get:
     - $ref: '../../components/security/security.yaml'
   parameters:
     - $ref: '../../components/parameters/q_person.yaml'
+    - $ref: '../../components/parameters/max.yaml'
     - $ref: '../../components/parameters/fulltext.yaml'
     - $ref: '../../components/parameters/pretty.yaml'
   responses:

--- a/api_src/paths/search/byterm.yaml
+++ b/api_src/paths/search/byterm.yaml
@@ -14,6 +14,7 @@ get:
   parameters:
     - $ref: '../../components/parameters/q.yaml'
     - $ref: '../../components/parameters/val.yaml'
+    - $ref: '../../components/parameters/max.yaml'
     - $ref: '../../components/parameters/aponly.yaml'
     - $ref: '../../components/parameters/clean.yaml'
     - $ref: '../../components/parameters/fulltext.yaml'

--- a/api_src/paths/search/bytitle.yaml
+++ b/api_src/paths/search/bytitle.yaml
@@ -18,6 +18,7 @@ get:
   parameters:
     - $ref: '../../components/parameters/q.yaml'
     - $ref: '../../components/parameters/val.yaml'
+    - $ref: '../../components/parameters/max.yaml'
     - $ref: '../../components/parameters/clean.yaml'
     - $ref: '../../components/parameters/fulltext.yaml'
     - $ref: '../../components/parameters/pretty.yaml'

--- a/api_src/paths/search/music/byterm.yaml
+++ b/api_src/paths/search/music/byterm.yaml
@@ -16,6 +16,7 @@ get:
     - $ref: '../../../components/parameters/q.yaml'
     - $ref: '../../../components/parameters/val.yaml'
     - $ref: '../../../components/parameters/aponly.yaml'
+    - $ref: '../../../components/parameters/max.yaml'
     - $ref: '../../../components/parameters/clean.yaml'
     - $ref: '../../../components/parameters/fulltext.yaml'
     - $ref: '../../../components/parameters/pretty.yaml'

--- a/api_src/root.yaml
+++ b/api_src/root.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  version: 1.9.0
+  version: 1.10.0
   title: PodcastIndex.org API
   termsOfService: 'https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md'
   contact:

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "version": "1.9.0",
+    "version": "1.10.0",
     "title": "PodcastIndex.org API",
     "termsOfService": "https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md",
     "contact": {
@@ -251,6 +251,27 @@
         },
         "allowEmptyValue": true,
         "required": true
+      },
+      "max_5000": {
+        "name": "max",
+        "in": "query",
+        "description": "Maximum number of results to return.\n",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5000
+        },
+        "example": 200
+      },
+      "start_at": {
+        "name": "start_at",
+        "in": "query",
+        "description": "Feed ID to start at for request\n",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "example": 1
       },
       "medium": {
         "name": "medium",
@@ -1677,6 +1698,11 @@
           }
         }
       },
+      "trendScore": {
+        "description": "The ranking for how the podcast is trending in the index\n",
+        "type": "integer",
+        "example": 1
+      },
       "valueCreatedOn": {
         "description": "The time this feed's `value` data added\n",
         "type": "integer",
@@ -1761,6 +1787,9 @@
           "locked": {
             "$ref": "#/components/schemas/locked"
           },
+          "popularity": {
+            "$ref": "#/components/schemas/trendScore"
+          },
           "imageUrlHash": {
             "$ref": "#/components/schemas/imageUrlHash"
           },
@@ -1785,15 +1814,20 @@
           "$ref": "#/components/schemas/feed_bytag"
         }
       },
+      "total": {
+        "description": "Total number of feeds returnable by endpoint\n",
+        "type": "integer",
+        "example": 13143
+      },
+      "nextStartAt": {
+        "description": "Feed ID to pass to next `start_at` to get next batch of feeds\n\nOnly returned when `start_at` passed to request\n",
+        "type": "integer",
+        "example": 322043
+      },
       "medium": {
         "description": "Value of `medium` parameter used in request\n",
         "type": "string",
         "example": "film"
-      },
-      "trendScore": {
-        "description": "The ranking for how the podcast is trending in the index\n",
-        "type": "integer",
-        "example": 1
       },
       "feed_trending": {
         "type": "object",
@@ -3300,6 +3334,12 @@
                 "count": {
                   "$ref": "#/components/schemas/count"
                 },
+                "total": {
+                  "$ref": "#/components/schemas/total"
+                },
+                "nextStartAt": {
+                  "$ref": "#/components/schemas/nextStartAt"
+                },
                 "description": {
                   "$ref": "#/components/schemas/description_response"
                 }
@@ -4316,7 +4356,7 @@
           "Podcasts"
         ],
         "summary": "By Tag",
-        "description": "This call returns all feeds that support the specified [podcast namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md) tag.\n\nExample: https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&pretty\n",
+        "description": "This call returns all feeds that support the specified [podcast namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md) tag.\n\nWhen called without a `start_at` value, the top 500 feeds sorted by popularity are returned in descending order.\n\nWhen called with a `start_at` value, the feeds are returned sorted by the `feedId` starting with the specified value up to the max number of feeds to return. The `nextStartAt` specifies the value to pass to the next `start_at`. Repeat this sequence until no items are returned.\n\nExamples:\n  - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&pretty\n  - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&start_at=1&pretty\n",
         "operationId": "podcasts/bytag",
         "security": [
           {
@@ -4329,6 +4369,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/podcast-value"
+          },
+          {
+            "$ref": "#/components/parameters/max_5000"
+          },
+          {
+            "$ref": "#/components/parameters/start_at"
           },
           {
             "$ref": "#/components/parameters/pretty"

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -1191,6 +1191,12 @@
         "format": "URL",
         "example": "https://studio.hypercatcher.com/chapters/podcast/http:feed.nashownotes.comrss.xml/episode/http:1322.noagendanotes.com"
       },
+      "transcriptUrl": {
+        "description": "Link to the file containing the episode transcript\n\nNote: in most use cases, the `transcripts` value should be used instead\n",
+        "type": "string",
+        "format": "URL",
+        "example": "https://mp3s.nashownotes.com/NA-1322-Captions.srt"
+      },
       "transcript": {
         "description": "This tag is used to link to a transcript or closed captions file. Multiple tags can be present for multiple transcript formats.\nDetailed file format information and example files are [here](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md).\n",
         "type": "object",
@@ -1297,6 +1303,9 @@
           },
           "chaptersUrl": {
             "$ref": "#/components/schemas/chaptersUrl"
+          },
+          "transcriptUrl": {
+            "$ref": "#/components/schemas/transcriptUrl"
           },
           "transcripts": {
             "$ref": "#/components/schemas/transcripts"
@@ -1957,12 +1966,6 @@
         "description": "Link TODO\n",
         "type": "string",
         "example": ""
-      },
-      "transcriptUrl": {
-        "description": "Link to the file containing the episode transcript\n\nNote: in most use cases, the `transcripts` value should be used instead\n",
-        "type": "string",
-        "format": "URL",
-        "example": "https://mp3s.nashownotes.com/NA-1322-Captions.srt"
       },
       "liveitem_podcast": {
         "type": "object",

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -1915,7 +1915,7 @@
         "example": ""
       },
       "transcriptUrl": {
-        "description": "Link to the file containing the episode transcript\n",
+        "description": "Link to the file containing the episode transcript\n\nNote: in most use cases, the `transcripts` value should be used instead\n",
         "type": "string",
         "format": "URL",
         "example": "https://mp3s.nashownotes.com/NA-1322-Captions.srt"
@@ -2370,17 +2370,35 @@
           "feedLanguage": {
             "$ref": "#/components/schemas/language"
           },
+          "feedDead": {
+            "$ref": "#/components/schemas/dead"
+          },
+          "feedDuplicateOf": {
+            "$ref": "#/components/schemas/duplicateOf"
+          },
           "chaptersUrl": {
             "$ref": "#/components/schemas/chaptersUrl"
           },
           "transcriptUrl": {
             "$ref": "#/components/schemas/transcriptUrl"
           },
+          "transcripts": {
+            "$ref": "#/components/schemas/transcripts"
+          },
           "soundbite": {
             "$ref": "#/components/schemas/soundbite"
           },
           "soundbites": {
             "$ref": "#/components/schemas/soundbites"
+          },
+          "persons": {
+            "$ref": "#/components/schemas/persons"
+          },
+          "socialInteract": {
+            "$ref": "#/components/schemas/socialInteract"
+          },
+          "value": {
+            "$ref": "#/components/schemas/value"
           }
         }
       },

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -165,6 +165,17 @@
         },
         "example": ""
       },
+      "max": {
+        "name": "max",
+        "in": "query",
+        "description": "Maximum number of results to return.\n",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "example": 10
+      },
       "aponly": {
         "name": "aponly",
         "in": "query",
@@ -290,17 +301,6 @@
           ]
         },
         "example": "film"
-      },
-      "max": {
-        "name": "max",
-        "in": "query",
-        "description": "Maximum number of results to return.\n",
-        "schema": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 1000
-        },
-        "example": 10
       },
       "since": {
         "name": "since",
@@ -4035,6 +4035,9 @@
             "$ref": "#/components/parameters/val"
           },
           {
+            "$ref": "#/components/parameters/max"
+          },
+          {
             "$ref": "#/components/parameters/aponly"
           },
           {
@@ -4098,6 +4101,9 @@
             "$ref": "#/components/parameters/val"
           },
           {
+            "$ref": "#/components/parameters/max"
+          },
+          {
             "$ref": "#/components/parameters/clean"
           },
           {
@@ -4144,6 +4150,9 @@
             "$ref": "#/components/parameters/q_person"
           },
           {
+            "$ref": "#/components/parameters/max"
+          },
+          {
             "$ref": "#/components/parameters/fulltext"
           },
           {
@@ -4188,6 +4197,9 @@
           },
           {
             "$ref": "#/components/parameters/aponly"
+          },
+          {
+            "$ref": "#/components/parameters/max"
           },
           {
             "$ref": "#/components/parameters/clean"
@@ -4422,6 +4434,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/medium"
+          },
+          {
+            "$ref": "#/components/parameters/max"
           },
           {
             "$ref": "#/components/parameters/pretty"

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -1644,6 +1644,9 @@
           "parseErrors": {
             "$ref": "#/components/schemas/parseErrors"
           },
+          "categories": {
+            "$ref": "#/components/schemas/categories"
+          },
           "locked": {
             "$ref": "#/components/schemas/locked"
           },

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -947,7 +947,7 @@
         "example": 0
       },
       "imageUrlHash": {
-        "description": "A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed. Can be used to retrieve a resized/converted version of the image specified by `image` from https://podcastimages.com/.\n\nUsing the format: `https://podcastimages.com/<hash>_<size>.jpg` Replace `<hash>` with the value in this field. The `<size>` is the desired image width/height. Ex: `https://podcastimages.com/1011338142_600.jpg`\n\n**Work in Progress**: the `podcastimages.com` system is currently not working.\n",
+        "description": "A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed.\n",
         "type": "integer",
         "example": 1639321931
       },
@@ -2409,6 +2409,11 @@
           "$ref": "#/components/schemas/item_itunesId"
         }
       },
+      "feedImageUrlHash": {
+        "description": "A CRC32 hash of the `feedImage` URL with the protocol (`http://`, `https://`) removed.\n",
+        "type": "integer",
+        "example": 1639321931
+      },
       "episode_object": {
         "description": "Episode data\n",
         "type": "object",
@@ -2464,11 +2469,17 @@
           "image": {
             "$ref": "#/components/schemas/image_episode"
           },
+          "imageUrlHash": {
+            "$ref": "#/components/schemas/imageUrlHash"
+          },
           "feedItunesId": {
             "$ref": "#/components/schemas/itunesId_feed"
           },
           "feedImage": {
             "$ref": "#/components/schemas/image_feed"
+          },
+          "feedImageUrlHash": {
+            "$ref": "#/components/schemas/feedImageUrlHash"
           },
           "feedId": {
             "$ref": "#/components/schemas/id_feed"

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -408,6 +408,16 @@
           }
         }
       },
+      "enclosure": {
+        "name": "enclosure",
+        "in": "query",
+        "description": "The URL for the episode enclosure to get the information for.\n",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "example": "https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3"
+      },
       "id_episode_pi": {
         "name": "id",
         "in": "query",
@@ -4519,7 +4529,7 @@
           "Episodes"
         ],
         "summary": "By Feed ID",
-        "description": "This call returns all the episodes we know about for this feed from the PodcastIndex ID. Episodes are in reverse chronological order.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty\n  - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty\n  - Includes `value`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=4058673&pretty\n",
+        "description": "This call returns all the episodes we know about for this feed from the PodcastIndex ID. Episodes are in reverse chronological order.\n\nWhen using the `enclosure` parameter, only the episode matching the URL is returned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty\n  - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty\n  - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty\n  - Includes `value`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=4058673&pretty\n  - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty\n",
         "operationId": "episodes/byfeedid",
         "security": [
           {
@@ -4538,6 +4548,9 @@
           },
           {
             "$ref": "#/components/parameters/max"
+          },
+          {
+            "$ref": "#/components/parameters/enclosure"
           },
           {
             "$ref": "#/components/parameters/fulltext"
@@ -4657,7 +4670,7 @@
           "Episodes"
         ],
         "summary": "By iTunes ID",
-        "description": "This call returns all the episodes we know about for this feed from the iTunes ID. Episodes are in reverse chronological order.\n\nExample: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty\n",
+        "description": "This call returns all the episodes we know about for this feed from the iTunes ID. Episodes are in reverse chronological order.\n\nWhen using the `enclosure` parameter, only the episode matching the URL is returned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty\n  - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=269169796&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty\n",
         "operationId": "episodes/byitunesid",
         "security": [
           {
@@ -4676,6 +4689,9 @@
           },
           {
             "$ref": "#/components/parameters/max"
+          },
+          {
+            "$ref": "#/components/parameters/enclosure"
           },
           {
             "$ref": "#/components/parameters/fulltext"

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -4119,7 +4119,7 @@
           "Search"
         ],
         "summary": "Search Episodes by Person",
-        "description": "This call returns all of the episodes where the specified person is mentioned.\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=adam%20curry&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Martin+Mouritzen&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Klaus+Schwab&pretty\n",
+        "description": "This call returns all of the episodes where the specified person is mentioned.\n\nIt searches the following fields:\n\n  - Person tags\n  - Episode title\n  - Episode description\n  - Feed owner\n  - Feed author\n\n\nExamples:\n\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=adam%20curry&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Martin+Mouritzen&pretty\n  - https://api.podcastindex.org/api/1.0/search/byperson?q=Klaus+Schwab&pretty\n",
         "operationId": "search/byperson",
         "security": [
           {

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -3770,6 +3770,15 @@ paths:
         mentioned.
 
 
+        It searches the following fields:
+
+          - Person tags
+          - Episode title
+          - Episode description
+          - Feed owner
+          - Feed author
+
+
         Examples:
 
           - https://api.podcastindex.org/api/1.0/search/byperson?q=adam%20curry&pretty

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1155,17 +1155,7 @@ components:
     imageUrlHash:
       description: >
         A CRC32 hash of the `image` URL with the protocol (`http://`,
-        `https://`) removed. Can be used to retrieve a resized/converted version
-        of the image specified by `image` from https://podcastimages.com/.
-
-
-        Using the format: `https://podcastimages.com/<hash>_<size>.jpg` Replace
-        `<hash>` with the value in this field. The `<size>` is the desired image
-        width/height. Ex: `https://podcastimages.com/1011338142_600.jpg`
-
-
-        **Work in Progress**: the `podcastimages.com` system is currently not
-        working.
+        `https://`) removed.
       type: integer
       example: 1639321931
     newestItemPublishTime:
@@ -2427,6 +2417,12 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/item_itunesId'
+    feedImageUrlHash:
+      description: >
+        A CRC32 hash of the `feedImage` URL with the protocol (`http://`,
+        `https://`) removed.
+      type: integer
+      example: 1639321931
     episode_object:
       description: |
         Episode data
@@ -2466,10 +2462,14 @@ components:
           $ref: '#/components/schemas/season'
         image:
           $ref: '#/components/schemas/image_episode'
+        imageUrlHash:
+          $ref: '#/components/schemas/imageUrlHash'
         feedItunesId:
           $ref: '#/components/schemas/itunesId_feed'
         feedImage:
           $ref: '#/components/schemas/image_feed'
+        feedImageUrlHash:
+          $ref: '#/components/schemas/feedImageUrlHash'
         feedId:
           $ref: '#/components/schemas/id_feed'
         feedTitle:

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -273,6 +273,16 @@ components:
           - hive
           - webmonetization
       example: ''
+    max:
+      name: max
+      in: query
+      description: |
+        Maximum number of results to return.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+      example: 10
     aponly:
       name: aponly
       in: query
@@ -407,16 +417,6 @@ components:
           - podcast
           - video
       example: film
-    max:
-      name: max
-      in: query
-      description: |
-        Maximum number of results to return.
-      schema:
-        type: integer
-        minimum: 1
-        maximum: 1000
-      example: 10
     since:
       name: since
       in: query
@@ -3547,6 +3547,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/q'
         - $ref: '#/components/parameters/val'
+        - $ref: '#/components/parameters/max'
         - $ref: '#/components/parameters/aponly'
         - $ref: '#/components/parameters/clean'
         - $ref: '#/components/parameters/fulltext'
@@ -3758,6 +3759,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/q'
         - $ref: '#/components/parameters/val'
+        - $ref: '#/components/parameters/max'
         - $ref: '#/components/parameters/clean'
         - $ref: '#/components/parameters/fulltext'
         - $ref: '#/components/parameters/pretty'
@@ -3801,6 +3803,7 @@ paths:
           Authorization: []
       parameters:
         - $ref: '#/components/parameters/q_person'
+        - $ref: '#/components/parameters/max'
         - $ref: '#/components/parameters/fulltext'
         - $ref: '#/components/parameters/pretty'
       responses:
@@ -3834,6 +3837,7 @@ paths:
         - $ref: '#/components/parameters/q'
         - $ref: '#/components/parameters/val'
         - $ref: '#/components/parameters/aponly'
+        - $ref: '#/components/parameters/max'
         - $ref: '#/components/parameters/clean'
         - $ref: '#/components/parameters/fulltext'
         - $ref: '#/components/parameters/pretty'
@@ -4028,6 +4032,7 @@ paths:
           Authorization: []
       parameters:
         - $ref: '#/components/parameters/medium'
+        - $ref: '#/components/parameters/max'
         - $ref: '#/components/parameters/pretty'
       responses:
         '200':

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -2005,6 +2005,8 @@ components:
     transcriptUrl:
       description: |
         Link to the file containing the episode transcript
+
+        Note: in most use cases, the `transcripts` value should be used instead
       type: string
       format: URL
       example: https://mp3s.nashownotes.com/NA-1322-Captions.srt
@@ -2399,14 +2401,26 @@ components:
           $ref: '#/components/schemas/id_feed'
         feedLanguage:
           $ref: '#/components/schemas/language'
+        feedDead:
+          $ref: '#/components/schemas/dead'
+        feedDuplicateOf:
+          $ref: '#/components/schemas/duplicateOf'
         chaptersUrl:
           $ref: '#/components/schemas/chaptersUrl'
         transcriptUrl:
           $ref: '#/components/schemas/transcriptUrl'
+        transcripts:
+          $ref: '#/components/schemas/transcripts'
         soundbite:
           $ref: '#/components/schemas/soundbite'
         soundbites:
           $ref: '#/components/schemas/soundbites'
+        persons:
+          $ref: '#/components/schemas/persons'
+        socialInteract:
+          $ref: '#/components/schemas/socialInteract'
+        value:
+          $ref: '#/components/schemas/value'
     items_itunesId:
       description: |
         List of episodes matching request

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  version: 1.9.0
+  version: 1.10.0
   title: PodcastIndex.org API
   termsOfService: https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md
   contact:
@@ -367,6 +367,25 @@ components:
         type: boolean
       allowEmptyValue: true
       required: true
+    max_5000:
+      name: max
+      in: query
+      description: |
+        Maximum number of results to return.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 5000
+      example: 200
+    start_at:
+      name: start_at
+      in: query
+      description: |
+        Feed ID to start at for request
+      schema:
+        type: integer
+        minimum: 1
+      example: 1
     medium:
       name: medium
       in: query
@@ -1807,6 +1826,11 @@ components:
           $ref: '#/components/schemas/podcastGuid_query'
         id:
           $ref: '#/components/schemas/id_guid_query'
+    trendScore:
+      description: |
+        The ranking for how the podcast is trending in the index
+      type: integer
+      example: 1
     valueCreatedOn:
       description: |
         The time this feed's `value` data added
@@ -1866,6 +1890,8 @@ components:
           $ref: '#/components/schemas/categories'
         locked:
           $ref: '#/components/schemas/locked'
+        popularity:
+          $ref: '#/components/schemas/trendScore'
         imageUrlHash:
           $ref: '#/components/schemas/imageUrlHash'
         value:
@@ -1882,16 +1908,23 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/feed_bytag'
+    total:
+      description: |
+        Total number of feeds returnable by endpoint
+      type: integer
+      example: 13143
+    nextStartAt:
+      description: |
+        Feed ID to pass to next `start_at` to get next batch of feeds
+
+        Only returned when `start_at` passed to request
+      type: integer
+      example: 322043
     medium:
       description: |
         Value of `medium` parameter used in request
       type: string
       example: film
-    trendScore:
-      description: |
-        The ranking for how the podcast is trending in the index
-      type: integer
-      example: 1
     feed_trending:
       type: object
       properties:
@@ -3054,6 +3087,10 @@ components:
                 $ref: '#/components/schemas/feeds_bytag'
               count:
                 $ref: '#/components/schemas/count'
+              total:
+                $ref: '#/components/schemas/total'
+              nextStartAt:
+                $ref: '#/components/schemas/nextStartAt'
               description:
                 $ref: '#/components/schemas/description_response'
     bymedium:
@@ -3921,8 +3958,19 @@ paths:
         tag.
 
 
-        Example:
-        https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&pretty
+        When called without a `start_at` value, the top 500 feeds sorted by
+        popularity are returned in descending order.
+
+
+        When called with a `start_at` value, the feeds are returned sorted by
+        the `feedId` starting with the specified value up to the max number of
+        feeds to return. The `nextStartAt` specifies the value to pass to the
+        next `start_at`. Repeat this sequence until no items are returned.
+
+
+        Examples:
+          - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&pretty
+          - https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value&max=200&start_at=1&pretty
       operationId: podcasts/bytag
       security:
         - API Key: []
@@ -3931,6 +3979,8 @@ paths:
           Authorization: []
       parameters:
         - $ref: '#/components/parameters/podcast-value'
+        - $ref: '#/components/parameters/max_5000'
+        - $ref: '#/components/parameters/start_at'
         - $ref: '#/components/parameters/pretty'
       responses:
         '200':

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -551,6 +551,15 @@ components:
         multiple:
           value: 41504,920666
           description: Multiple IDs
+    enclosure:
+      name: enclosure
+      in: query
+      description: |
+        The URL for the episode enclosure to get the information for.
+      required: false
+      schema:
+        type: string
+      example: https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3
     id_episode_pi:
       name: id
       in: query
@@ -4097,12 +4106,17 @@ paths:
         PodcastIndex ID. Episodes are in reverse chronological order.
 
 
+        When using the `enclosure` parameter, only the episode matching the URL
+        is returned.
+
+
         Examples:
 
           - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=75075&pretty
           - https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504,920666&pretty
           - Includes `persons`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=169991&pretty
           - Includes `value`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=4058673&pretty
+          - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=41504&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty
       operationId: episodes/byfeedid
       security:
         - API Key: []
@@ -4113,6 +4127,7 @@ paths:
         - $ref: '#/components/parameters/id_feed_episode_pi'
         - $ref: '#/components/parameters/since'
         - $ref: '#/components/parameters/max'
+        - $ref: '#/components/parameters/enclosure'
         - $ref: '#/components/parameters/fulltext'
         - $ref: '#/components/parameters/pretty'
       responses:
@@ -4199,8 +4214,14 @@ paths:
         iTunes ID. Episodes are in reverse chronological order.
 
 
-        Example:
-        https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty
+        When using the `enclosure` parameter, only the episode matching the URL
+        is returned.
+
+
+        Examples:
+
+          - https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=1441923632&pretty
+          - Using `enclosure`: https://api.podcastindex.org/api/1.0/episodes/byitunesid?id=269169796&enclosure=https://op3.dev/e/mp3s.nashownotes.com/NA-1551-2023-04-30-Final.mp3&pretty
       operationId: episodes/byitunesid
       security:
         - API Key: []
@@ -4211,6 +4232,7 @@ paths:
         - $ref: '#/components/parameters/id_feed_podcast_itunes'
         - $ref: '#/components/parameters/since'
         - $ref: '#/components/parameters/max'
+        - $ref: '#/components/parameters/enclosure'
         - $ref: '#/components/parameters/fulltext'
         - $ref: '#/components/parameters/pretty'
       responses:

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1785,6 +1785,8 @@ components:
           $ref: '#/components/schemas/crawlErrors'
         parseErrors:
           $ref: '#/components/schemas/parseErrors'
+        categories:
+          $ref: '#/components/schemas/categories'
         locked:
           $ref: '#/components/schemas/locked'
         funding:

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1380,6 +1380,14 @@ components:
       format: URL
       example: >-
         https://studio.hypercatcher.com/chapters/podcast/http:feed.nashownotes.comrss.xml/episode/http:1322.noagendanotes.com
+    transcriptUrl:
+      description: |
+        Link to the file containing the episode transcript
+
+        Note: in most use cases, the `transcripts` value should be used instead
+      type: string
+      format: URL
+      example: https://mp3s.nashownotes.com/NA-1322-Captions.srt
     transcript:
       description: >
         This tag is used to link to a transcript or closed captions file.
@@ -1464,6 +1472,8 @@ components:
           $ref: '#/components/schemas/language'
         chaptersUrl:
           $ref: '#/components/schemas/chaptersUrl'
+        transcriptUrl:
+          $ref: '#/components/schemas/transcriptUrl'
         transcripts:
           $ref: '#/components/schemas/transcripts'
     items_byperson:
@@ -2034,14 +2044,6 @@ components:
         Link TODO
       type: string
       example: ''
-    transcriptUrl:
-      description: |
-        Link to the file containing the episode transcript
-
-        Note: in most use cases, the `transcripts` value should be used instead
-      type: string
-      format: URL
-      example: https://mp3s.nashownotes.com/NA-1322-Captions.srt
     liveitem_podcast:
       type: object
       properties:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi_api_docs",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "devDependencies": {
     "@redocly/openapi-cli": "^1.0.0-beta.80",


### PR DESCRIPTION
Various updates:

- Update version to 1.10
- Add categories to `podcasts/byitunesid`
- Add missing fields to `episodes/byitunesid`
- Add `imageUrlHash` and `feedImageUrlHash` to `episodes/byguid`
    - Remove note about podcastimages.com since domain is no longer registered
- Add updated description of `podcasts/bytag` (https://podcastindex.social/@dave/110236825931831170)
- Fix default `User-Agent` in Postman files since default from docs is rejected
- Update description of fields used in `search/byperson` (https://podcastindex.social/@dave/109942955488647312)
- Add description of enclosure parameter for `episodes/byfeedid` and `episodes/byitunesid` (https://podcastindex.social/@dave/109954913911423061)
- Add max parameter to `search/byperson`, `search/byterm`, `search/bytitle`, `search/music/byterm`, `podcasts/bymedium` (https://podcastindex.social/@dave/110074339879578390)




