### PR TITLE
Closes #122 - Include feedUrl, podcastGuid in /episodes/byfeedurl, /episodes/bypodcastguid, /episodes/byfeedid

### DIFF
--- a/api_src/components/schemas/item_podcast.yaml
+++ b/api_src/components/schemas/item_podcast.yaml
@@ -36,10 +36,14 @@ properties:
     $ref: '../properties/image_episode.yaml'
   feedItunesId:
     $ref: '../properties/itunesId_feed.yaml'
+  feedUrl:
+    $ref: '../properties/url_feed.yaml'
   feedImage:
     $ref: '../properties/image_feed.yaml'
   feedId:
     $ref: '../properties/id_feed.yaml'
+  podcastGuid:
+    $ref: '../properties/podcastguid.yaml'
   feedLanguage:
     $ref: '../properties/language.yaml'
   feedDead:

--- a/api_src/root.yaml
+++ b/api_src/root.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  version: 1.12.0
+  version: 1.12.1
   title: PodcastIndex.org API
   termsOfService: 'https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md'
   contact:

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "version": "1.12.0",
+    "version": "1.12.1",
     "title": "PodcastIndex.org API",
     "termsOfService": "https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md",
     "contact": {

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -4021,11 +4021,17 @@
           "feedItunesId": {
             "$ref": "#/components/schemas/itunesId_feed"
           },
+          "feedUrl": {
+            "$ref": "#/components/schemas/url_feed"
+          },
           "feedImage": {
             "$ref": "#/components/schemas/image_feed"
           },
           "feedId": {
             "$ref": "#/components/schemas/id_feed"
+          },
+          "podcastGuid": {
+            "$ref": "#/components/schemas/podcastguid"
           },
           "feedLanguage": {
             "$ref": "#/components/schemas/language"

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  version: 1.12.0
+  version: 1.12.1
   title: PodcastIndex.org API
   termsOfService: https://github.com/Podcastindex-org/legal/blob/main/TermsOfService.md
   contact:

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -3756,10 +3756,14 @@ components:
           $ref: '#/components/schemas/image_episode'
         feedItunesId:
           $ref: '#/components/schemas/itunesId_feed'
+        feedUrl:
+          $ref: '#/components/schemas/url_feed'
         feedImage:
           $ref: '#/components/schemas/image_feed'
         feedId:
           $ref: '#/components/schemas/id_feed'
+        podcastGuid:
+          $ref: '#/components/schemas/podcastguid'
         feedLanguage:
           $ref: '#/components/schemas/language'
         feedDead:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi_api_docs",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "devDependencies": {
     "@redocly/cli": "^1.10.6",


### PR DESCRIPTION
Closes #122 

### Changes
- Update `item_podcast.yaml` to reference `feedUrl` and `podcastGuid`
- run `yarn build` to generate postman docs
- Version bump from `1.12.0` to `1.12.1`

### Before/After
![before-after-122](https://github.com/Podcastindex-org/docs-api/assets/12632889/daa5b128-ff84-4180-a8b8-ac06361a52b1)

### Notes
- I didn't make any changes to `/episodes/byitunesid` because that endpoint doesn't actually return the `podcastGuid` and `feedUrl` like the others. Based on https://github.com/Podcastindex-org/docs-api/pull/94/commits/27e6c3a3261b8a5a483d117dfe2e8211633b6358 , it looks like not returning those fields is by design.