### PR TITLE
Add "format" to the "imageUrlHash" field in the OpenAPI spec because …

### DIFF
--- a/api_src/components/properties/imageUrlHash.yaml
+++ b/api_src/components/properties/imageUrlHash.yaml
@@ -1,5 +1,5 @@
   # language=Markdown
 description: |
-  A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed.
+  A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed. 64bit integer.
 type: integer
-example: 1639321931
+example: 3969216649

--- a/docs/pi_api.json
+++ b/docs/pi_api.json
@@ -2685,7 +2685,8 @@
       "imageUrlHash": {
         "description": "A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed.\n",
         "type": "integer",
-        "example": 1639321931
+        "format": "int64",
+        "example": 3969216649
       },
       "newestItemPublishTime": {
         "description": "The time the most recent episode in the feed was published.\n\n\nNote: some endpoints use `newestItemPubdate` while others use `newestItemPublishTime`. \nThey return the same information. See https://github.com/Podcastindex-org/api/issues/3 to track when the property name is updated.\n",

--- a/docs/pi_api.yaml
+++ b/docs/pi_api.yaml
@@ -2620,7 +2620,8 @@ components:
       description: |
         A CRC32 hash of the `image` URL with the protocol (`http://`, `https://`) removed.
       type: integer
-      example: 1639321931
+      format: int64
+      example: 3969216649
     newestItemPublishTime:
       description: |
         The time the most recent episode in the feed was published.


### PR DESCRIPTION
https://github.com/Podcastindex-org/docs-api/issues/135